### PR TITLE
Metrics and Alerting with Prometheus

### DIFF
--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -1,6 +1,7 @@
 ## These are some common variables for Make
 crossplane_sentinel = $(kind_dir)/crossplane-sentinel
 k8up_sentinel = $(kind_dir)/k8up-sentinel
+prometheus_sentinel = $(kind_dir)/prometheus-sentinel
 
 PROJECT_ROOT_DIR = .
 PROJECT_NAME ?= appcat-service-prototype

--- a/crossplane/composite.yaml
+++ b/crossplane/composite.yaml
@@ -97,3 +97,9 @@ spec:
                           type: string
                         window: # ??
                           type: string
+                    alerts:
+                      type: object
+                      properties:
+                        enabled:
+                          type: boolean
+                          default: false

--- a/crossplane/composition.yaml
+++ b/crossplane/composition.yaml
@@ -132,6 +132,13 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 128Mi
+              metrics:
+                enabled: true
+                serviceMonitor:
+                  enabled: true
+                prometheusRule:
+                  enabled: false
+                  rules: [] # tbd
           reclaimPolicy: Delete
           rollbackLimit: 3
       patches:

--- a/crossplane/composition.yaml
+++ b/crossplane/composition.yaml
@@ -135,9 +135,9 @@ spec:
               metrics:
                 enabled: true
                 serviceMonitor:
-                  enabled: true
+                  enabled: false # patched from instance
                 prometheusRule:
-                  enabled: true
+                  enabled: false # patched from instance
                   rules:
                     - alert: RedisDown
                       expr: redis_up{service="{{ template "redis.fullname" . }}-metrics"} == 0
@@ -209,6 +209,17 @@ spec:
                 # Simulating an older Redis version.
                 # If removed from the map, instances that use this version become unready, unless they pin the composition revision and set `compositionUpdatePolicy=Manual`
                 stable-5: 12.9.0
+        # Alerting enabled
+        - fromFieldPath: spec.parameters.alerts.enabled
+          toFieldPath: spec.forProvider.values.metrics.prometheusRule.enabled
+        - fromFieldPath: spec.parameters.alerts.enabled
+          toFieldPath: spec.forProvider.values.metrics.serviceMonitor.enabled
+          # Unfortunately map-type patches only works with strings, but the Helm chart expects boolean
+            # transforms:
+            #   - type: map
+            #     map:
+            #       guaranteed: "true"
+            #       besteffort: "false"
         # Namespace patches
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: spec.forProvider.namespace

--- a/crossplane/composition.yaml
+++ b/crossplane/composition.yaml
@@ -137,8 +137,25 @@ spec:
                 serviceMonitor:
                   enabled: true
                 prometheusRule:
-                  enabled: false
-                  rules: [] # tbd
+                  enabled: true
+                  rules:
+                    - alert: RedisDown
+                      expr: redis_up{service="{{ template "redis.fullname" . }}-metrics"} == 0
+                      for: 2m
+                      labels:
+                        severity: error
+                      annotations:
+                        summary: Redis(TM) instance {{ "{{ $labels.instance }}" }} down
+                        description: Redis(TM) instance {{ "{{ $labels.instance }}" }} is down
+                    - alert: RedisMissingMaster
+                      expr: (count(redis_instance_info{role="master"}) or vector(0)) < 1
+                      for: 2m
+                      labels:
+                        severity: error
+                      annotations:
+                        summary: Redis missing master (instance {{ "{{ $labels.instance }}" }})
+                        description: >
+                          Redis cluster has no node marked as master.\n  VALUE = {{ "{{ $value }}" }}\n  LABELS = {{ "{{ $labels }}" }}
           reclaimPolicy: Delete
           rollbackLimit: 3
       patches:

--- a/crossplane/composition.yaml
+++ b/crossplane/composition.yaml
@@ -147,6 +147,7 @@ spec:
                       annotations:
                         summary: Redis(TM) instance {{ "{{ $labels.instance }}" }} down
                         description: Redis(TM) instance {{ "{{ $labels.instance }}" }} is down
+                        runbook_url: https://vshn.github.io/appcat-service-prototype/appcat-service-prototype/runbooks/RedisDown.html
                     - alert: RedisMissingMaster
                       expr: (count(redis_instance_info{role="master"}) or vector(0)) < 1
                       for: 2m
@@ -156,6 +157,7 @@ spec:
                         summary: Redis missing master (instance {{ "{{ $labels.instance }}" }})
                         description: >
                           Redis cluster has no node marked as master.\n  VALUE = {{ "{{ $value }}" }}\n  LABELS = {{ "{{ $labels }}" }}
+                        runbook_url: https://vshn.github.io/appcat-service-prototype/appcat-service-prototype/runbooks/RedisMissingMaster.html
           reclaimPolicy: Delete
           rollbackLimit: 3
       patches:

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -16,3 +16,7 @@
 * xref:explanations/sli.adoc[Service Level Indicators]
 * xref:explanations/backup.adoc[Instance Backups]
 * xref:explanations/restore.adoc[Instance Restores]
+
+.Runbooks
+* xref:runbooks/RedisDown.adoc[RedisDown]
+* xref:runbooks/RedisMissingMaster.adoc[RedisMissingMaster]

--- a/docs/modules/ROOT/pages/runbooks/RedisDown.adoc
+++ b/docs/modules/ROOT/pages/runbooks/RedisDown.adoc
@@ -1,0 +1,12 @@
+= Alert rule: RedisDown
+
+== icon:glasses[] Overview
+
+This rule checks if a Redis Pod is down.
+If a Pod is down for 2 minutes, this rule will alert.
+It will inform which Pod is affected, for example `pos="redis-master-0"`.
+
+== icon:bug[] Steps for Debugging
+
+Check why the affected Pod is down.
+Use `kubectl describe pod <pod-name>`, `kubectl events` or check the logs of any other Kubernetes related pod debugging resource.

--- a/docs/modules/ROOT/pages/runbooks/RedisMissingMaster.adoc
+++ b/docs/modules/ROOT/pages/runbooks/RedisMissingMaster.adoc
@@ -1,0 +1,11 @@
+= Alert rule: RedisMissingMaster
+
+== icon:glasses[] Overview
+
+This Alert will be thrown if a Redis cluster has no master configured (no Redis Pod has `role=master`) for more than 2 minutes.
+
+== icon:bug[] Steps for Debugging
+
+Check all the Redis Pods in the namespace of the affected Pod and see why no Pod is elected as master.
+
+NOTE: Dummy content, this is just a prototype.

--- a/prometheus/values.yaml
+++ b/prometheus/values.yaml
@@ -1,0 +1,33 @@
+kubeEtcd:
+  enabled: false
+kubeScheduler:
+  enabled: false
+kubeProxy:
+  enabled: false
+kubeControllerManager:
+  enabled: false
+grafana:
+  enabled: false
+
+alertmanager:
+  alertmanagerSpec:
+    routePrefix: /alertmanager/
+  ingress:
+    enabled: true
+    hosts:
+      - 127.0.0.1.nip.io
+    paths:
+      - /alertmanager/
+
+prometheus:
+  prometheusSpec:
+    routePrefix: /prometheus/
+    # these will cause Prometheus to search in all namespaces
+    serviceMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+  ingress:
+    enabled: true
+    hosts:
+      - 127.0.0.1.nip.io
+    paths:
+      - /prometheus/

--- a/service/prototype-instance.yaml
+++ b/service/prototype-instance.yaml
@@ -17,3 +17,9 @@ spec:
         memory: 0.2Gi
     updatePolicy:
       version: stable-6
+    alerts:
+      # We have to use actual boolean flags if we want to (de)activate PrometheusRule in the helm chart (passthrough value),
+      # since Compositions doesn't offer patches with expression evaluation (e.g. `if sla == "guaranteed" then true else false`),
+      # not even boolean negations.
+      # We also can't use map-patches since map patches are map[string]string but the chart expects boolean values and fails if they're strings.
+      enabled: true


### PR DESCRIPTION
* Adds `make prometheus-setup` to install Prometheus and its Operator in local kind cluster
* Configures 2 alerts in the Redis helm chart that deploys a ServiceMonitor for Prometheus
* Adds a dummy runbook for the alerts.