### PR TITLE
Add Service architecture type considerations in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,21 @@ Also possible are so-called "umbrella" charts, which list other charts as depend
 For compositions that deploy the service with Helm this might be interesting, however compositions that can directly deploy cloud-provider-specific service instances using Crossplane providers this may be without dependencies.
 
 The most flexible solution would be to write a custom Crossplane provider.
+
+### Service Architecture Choice
+
+The current idea is to provision multiple types of service architecture.
+For example "Standalone", "Replicated", "Clustered" or "Cloud Instance".
+
+Since it's in most cases impossible to easily switch from one type to the other, it makes sense to create a dedicated CRD for each type of architecture, for example
+- `RedisStandaloneInstance`
+- `RedisReplicatedInstance`
+- `RedisClusteredInstance`
+- `RedisCloudInstance`
+
+instead of relying on a single CRD that offers an enum in the API specs.
+
+This avoids having to "switch-case" specs in the CRD API scheme, or immutable fields after creation or other measures that make the API spec rather confusing ("which fields are relevant for which type...?").
+
+And probably most importantly; it conveys a clear message to the user that architecture types cannot be changed from one to the other.
+Customers would have to provision new instance and migrate their data.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Deployments are left untouched, so that should give a last resort to either upgr
 
 Using this approach doesn't strictly need the new `CompositionRevision` feature, but it may be useful in other cases.
 
+This approach could also be more efficiently handled by a custom Crossplane provider.
+
 ### Deploying additional resources
 
 Common Helm charts for apps like Redis, MariaDB etc. don't come with all the resources that are required for operating AppCat service catalog with our standards.
@@ -107,3 +109,5 @@ Whether this chart can be generic for all services or a dedicated one for each s
 
 Also possible are so-called "umbrella" charts, which list other charts as dependency and can deploy additional resources.
 For compositions that deploy the service with Helm this might be interesting, however compositions that can directly deploy cloud-provider-specific service instances using Crossplane providers this may be without dependencies.
+
+The most flexible solution would be to write a custom Crossplane provider.


### PR DESCRIPTION
I added some thoughts that I had when thinking about CRD API design specs for ordering services.

Considering that switching from one type to another is very hard and a huge effort in the implementation, I would actively prohibit changing it in the same instance. Thus the idea of an architecture type in different CRDs.
It allows per-service-architecture specific API specs that may be irrelevant in others.