### PR TITLE
Determine service instance runtime with Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This will
 1. Install a local Kubernetes cluster with kubernetes-in-docker (`kind`)
 1. Install Crossplane Helm chart
 1. Install Secrets Generator Helm chart (for providing random passwords)
+1. Install Prometheus Operator and a Prometheus instance with AlertManager
 1. Install a CompositeResourceDefinition for the prototype service
 1. Install a Composition for the prototype service
 1. Deploy a service instance of the prototype
@@ -31,6 +32,13 @@ The prototype service is a simple Redis instance.
 To uninstall, either run
 - `make deprovision` to just uninstall the service instance.
 - `make clean` to completely remove the cluster and all artifacts.
+
+## Monitoring
+
+A monitoring stack with Prometheus will also be installed and monitors the Redis instance as well as backups.
+The stack can also be used for billing purposes.
+In `service/billing.promql` is a sample PromQL query that can be used to count how long a certain Redis instance is "provisioned".
+Enter this query in http://127.0.0.1.nip.io:8081/prometheus/ after provisioning.
 
 ## How it works
 

--- a/crossplane/composition.yaml
+++ b/crossplane/composition.yaml
@@ -37,6 +37,15 @@ spec:
         kind: Namespace  # Let the composition manage the namespace, Crossplane will clean it up if deprovisioned
         metadata:
           name: "" # patched from composite
+          labels:
+            # We will abuse these labels to provide metrics that can be picked up by kube-state-metrics' `kube_secret_labels`.
+            # This will allow us to compute how many minutes an instance is running for billing purposes.
+            # This should be considered a workaround since there could be multiple namespaces involved in a single service, or none at all.
+            # But this serves well for a prototype.
+            service.syn.tools/name: redis
+            service.syn.tools/architecture: standalone
+            service.syn.tools/sla: besteffort # we currently can't switch to "guaranteed" based on whether alerting is enabled
+            service.syn.tools/backups: enabled
       patches:
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name

--- a/prometheus/values.yaml
+++ b/prometheus/values.yaml
@@ -1,3 +1,5 @@
+# See https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack
+
 kubeEtcd:
   enabled: false
 kubeScheduler:
@@ -31,3 +33,8 @@ prometheus:
       - 127.0.0.1.nip.io
     paths:
       - /prometheus/
+
+# See https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics
+kube-state-metrics:
+  metricLabelsAllowlist:
+    - namespaces=[*]

--- a/service/billing.promql
+++ b/service/billing.promql
@@ -1,0 +1,18 @@
+# Sum values over one hour.
+sum_over_time(
+  # Get the base product identifier
+  label_replace(
+    # Get the number of Redis standalone instances with "besteffort" SLA
+    sum by(label_crossplane_io_claim_namespace,label_crossplane_io_claim_name)
+      (kube_namespace_labels{label_service_syn_tools_name="redis",label_service_syn_tools_sla="besteffort", label_service_syn_tools_architecture="standalone"}
+    ),
+    "product",
+    "appcat_redis_standalone_besteffort",
+    "product",
+    ".*"
+  )[59m:1m]
+)
+
+
+# Inspired by
+# https://github.com/appuio/appuio-cloud-reporting/blob/master/pkg/db/seeds/appuio_cloud_loadbalancer.promql

--- a/service/billing.promql
+++ b/service/billing.promql
@@ -7,12 +7,16 @@ sum_over_time(
       (kube_namespace_labels{label_service_syn_tools_name="redis",label_service_syn_tools_sla="besteffort", label_service_syn_tools_architecture="standalone"}
     ),
     "product",
-    "appcat_redis_standalone_besteffort",
-    "product",
-    ".*"
-  )[59m:1m]
+    # Combine to full qualifier with some static info
+    "appcat_redis_standalone_besteffort:kind-local-cluster:my-tenant:$1",
+    "label_crossplane_io_claim_namespace",
+    "(.*)"
+  )
+  [59m:1m]
 )
 
 
-# Inspired by
+# Inspired by:
 # https://github.com/appuio/appuio-cloud-reporting/blob/master/pkg/db/seeds/appuio_cloud_loadbalancer.promql
+# Data model:
+# https://kb.vshn.ch/appuio-cloud/references/architecture/metering-data-flow.html


### PR DESCRIPTION
* Abuse namespace labels to provide metrics for Prometheus
  A better option would be to provide metrics from Crossplane (or provider) since there might not always be a namespace. But it's okay in this prototype.
* Add sample PromQL query to count how long instances are running in a time frame
* Mention monitoring stack in Readme